### PR TITLE
Corrects http port in defaults and docs to 9411

### DIFF
--- a/play-zipkin-tracing/core/src/main/scala/jp/co/bizreach/trace/ZipkinTraceServiceLike.scala
+++ b/play-zipkin-tracing/core/src/main/scala/jp/co/bizreach/trace/ZipkinTraceServiceLike.scala
@@ -22,7 +22,7 @@ import scala.util.{Success, Try, Failure}
  *   val tracer = Tracer.newBuilder()
  *     .localServiceName("example")
  *     .reporter(AsyncReporter
- *       .builder(OkHttpSender.create("http://localhost:9410/api/v1/spans"))
+ *       .builder(OkHttpSender.create("http://localhost:9411/api/v1/spans"))
  *       .build()
  *     )
  *     .sampler(Sampler.create(0.1F))

--- a/play-zipkin-tracing/play23/README.md
+++ b/play-zipkin-tracing/play23/README.md
@@ -21,7 +21,7 @@ trace {
 
   zipkin {
     host = "localhost"
-    port = 9410
+    port = 9411
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
@@ -23,7 +23,7 @@ object ZipkinTraceService extends ZipkinTraceServiceLike {
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "example")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9410}/api/v1/spans"
+        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
       ))
       .build()
     )

--- a/play-zipkin-tracing/play24/README.md
+++ b/play-zipkin-tracing/play24/README.md
@@ -25,7 +25,7 @@ trace {
 
   zipkin {
     host = "localhost"
-    port = 9410
+    port = 9411
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
@@ -28,7 +28,7 @@ class ZipkinTraceService @Inject() (
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "example")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9410}/api/v1/spans"
+        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
       ))
       .build()
     )

--- a/play-zipkin-tracing/play25/README.md
+++ b/play-zipkin-tracing/play25/README.md
@@ -23,7 +23,7 @@ trace {
 
   zipkin {
     host = "localhost"
-    port = 9410
+    port = 9411
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
@@ -28,7 +28,7 @@ class ZipkinTraceService @Inject() (
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "example")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9410}/api/v1/spans"
+        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
       ))
       .build()
     )


### PR DESCRIPTION
Port 9410 is the deprecated Scribe port. In docs and code, the intended
transport is http, which listens by default on 9411.

See https://github.com/openzipkin/zipkin/issues/1192