### PR TITLE
Allow nested local tracing

### DIFF
--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -60,7 +60,8 @@ lazy val core = (project in file("core")).
     libraryDependencies ++= Seq(
       "commons-lang" % "commons-lang" % "2.6",
       "io.zipkin.brave" % "brave" % "4.0.6",
-      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "0.6.12"
+      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "0.6.12",
+      "org.scalatest" %% "scalatest" % "3.0.2" % "test"
     )
   )
 

--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "jp.co.bizreach",
-  version := "1.0.0",
+  version := "1.1.0-SNAPSHOT",
   scalaVersion := "2.11.8",
   publishMavenStyle := true,
   publishTo := {

--- a/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
+++ b/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
@@ -1,0 +1,50 @@
+package jp.co.bizreach.trace
+
+import brave.Tracer
+import org.scalatest.FunSuite
+import zipkin.Span
+import zipkin.reporter.Reporter
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext
+
+
+class ZipkinTraceServiceLikeSpec extends FunSuite {
+
+  private def initialTraceData(tracer: ZipkinTraceServiceLike, header: Map[String, String]): TraceData = {
+    TraceData(tracer.newSpan[Map[String, String]](header)((headers: Map[String, String], key: String) => headers.get(key)))
+  }
+
+  test("Nested client tracing"){
+    val tracer = new TestZipkinTraceService()
+    implicit val traceData = initialTraceData(tracer, Map.empty)
+
+    tracer.trace("trace-1"){ implicit traceData =>
+      tracer.trace("trace-2"){ implicit traceData =>
+        println("Hello World!")
+      }
+    }
+
+    Thread.sleep(500)
+    assert(tracer.reporter.spans.length == 2)
+
+    val parent = tracer.reporter.spans.find(_.name == "trace-1").get
+    val child  = tracer.reporter.spans.find(_.name == "trace-2").get
+
+    assert(parent.id == child.parentId)
+    assert(parent.id != child.id)
+    assert(parent.duration > child.duration)
+  }
+
+}
+
+class TestZipkinTraceService extends ZipkinTraceServiceLike {
+  override implicit val executionContext: ExecutionContext = ExecutionContext.global
+  val reporter = new TestReporter()
+  override val tracer: Tracer = Tracer.newBuilder().reporter(reporter).build()
+}
+
+class TestReporter extends Reporter[Span] {
+  val spans = new ListBuffer[Span]()
+  override def report(span: Span): Unit = spans += span
+}

--- a/play-zipkin-tracing/play23/README.md
+++ b/play-zipkin-tracing/play23/README.md
@@ -63,7 +63,7 @@ class ApiController extends Controller with ZipkinTraceImplicits {
 
   // Trace blocking action
   def test1 = Action { implicit request =>
-    ZipkinTraceService.trace("sync"){
+    ZipkinTraceService.trace("sync"){ implicit traceData =>
       println("Hello World!")
       Ok(Json.obj("result" -> "ok"))
     }
@@ -71,7 +71,7 @@ class ApiController extends Controller with ZipkinTraceImplicits {
 
   // Trace async action
   def test2 = Action.async { implicit request =>
-    ZipkinTraceService.traceFuture("async"){
+    ZipkinTraceService.traceFuture("async"){ implicit traceData =>
       Future {
         println("Hello World!")
         Ok(Json.obj("result" -> "ok"))

--- a/play-zipkin-tracing/play24/README.md
+++ b/play-zipkin-tracing/play24/README.md
@@ -77,7 +77,7 @@ class ApiController @Inject() (ws: TraceWSClient)
 
   // Trace blocking action
   def test1 = Action { implicit request =>
-    tracer.trace("sync"){
+    tracer.trace("sync"){ implicit traceData =>
       println("Hello World!")
       Ok(Json.obj("result" -> "ok"))
     }
@@ -85,7 +85,7 @@ class ApiController @Inject() (ws: TraceWSClient)
 
   // Trace async action
   def test2 = Action.async { implicit request =>
-    tracer.traceFuture("async"){
+    tracer.traceFuture("async"){ implicit traceData =>
       Future {
         println("Hello World!")
         Ok(Json.obj("result" -> "ok"))

--- a/play-zipkin-tracing/play25/README.md
+++ b/play-zipkin-tracing/play25/README.md
@@ -73,7 +73,7 @@ class ApiController @Inject() (ws: TraceWSClient)
 
   // Trace blocking action
   def test1 = Action { implicit request =>
-    tracer.trace("sync"){
+    tracer.trace("sync"){ implicit traceData =>
       println("Hello World!")
       Ok(Json.obj("result" -> "ok"))
     }
@@ -81,7 +81,7 @@ class ApiController @Inject() (ws: TraceWSClient)
 
   // Trace async action
   def test2 = Action.async { implicit request =>
-    tracer.traceFuture("async"){
+    tracer.traceFuture("async"){ implicit traceData =>
       Future {
         println("Hello World!")
         Ok(Json.obj("result" -> "ok"))

--- a/sample/zipkin-api-play23/build.sbt
+++ b/sample/zipkin-api-play23/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play23" % "1.0.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play23" % "1.1.0-SNAPSHOT"
 )
 
 

--- a/sample/zipkin-api-play24/build.sbt
+++ b/sample/zipkin-api-play24/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play24" % "1.0.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play24" % "1.1.0-SNAPSHOT"
 )
 
 

--- a/sample/zipkin-api-play25/app/services/ApiSampleService.scala
+++ b/sample/zipkin-api-play25/app/services/ApiSampleService.scala
@@ -17,9 +17,11 @@ class ApiSampleService @Inject() (
 ) {
 
   def sample(url: String)(implicit traceData: TraceData): Future[String] = {
-    tracer.trace("local-wait"){
-      Thread.sleep(300 + Random.nextInt(700))
+    tracer.trace("local-wait-1"){ implicit traceData =>
+      tracer.trace("local-wait-2"){ implicit traceData =>
+        Thread.sleep(300 + Random.nextInt(700))
+      }
+      repo.call(url)
     }
-    repo.call(url)
   }
 }

--- a/sample/zipkin-api-play25/build.sbt
+++ b/sample/zipkin-api-play25/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
 val AkkaVersion = "2.4.11"
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play25" % "1.0.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play25" % "1.1.0-SNAPSHOT"
 )
 
 PlayKeys.playDefaultPort := 9991


### PR DESCRIPTION
Allow nested local tracing like:

```scala
def sample(url: String)(implicit traceData: TraceData): Future[String] = {
  tracer.trace("local-wait-1"){ implicit traceData =>
    tracer.trace("local-wait-2"){ implicit traceData =>
      Thread.sleep(300 + Random.nextInt(700))
    }
    repo.call(url)
  }
}
```

Results in Zipkin UI:

![nested-local-trace](https://cloud.githubusercontent.com/assets/1094760/25160771/0ce06df4-24f3-11e7-8e95-b66a7e93ba21.png)


This pull request fixes #13