### PR TITLE
Updates to latest brave version (4.3.3).

### DIFF
--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "jp.co.bizreach",
-  version := "1.1.0",
+  version := "1.2.0-SNAPSHOT",
   scalaVersion := "2.11.8",
   publishMavenStyle := true,
   publishTo := {
@@ -60,9 +60,9 @@ lazy val core = (project in file("core")).
     name := "play-zipkin-tracing-core",
     libraryDependencies ++= Seq(
       "commons-lang" % "commons-lang" % "2.6",
-      "io.zipkin.brave" % "brave" % "4.0.6",
-      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "0.6.12",
-      "org.scalatest" %% "scalatest" % "3.0.2" % "test"
+      "io.zipkin.brave" % "brave" % "4.3.3",
+      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "0.10.0",
+      "org.scalatest" %% "scalatest" % "3.0.3" % "test"
     )
   )
 

--- a/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
+++ b/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
@@ -1,6 +1,6 @@
 package jp.co.bizreach.trace
 
-import brave.Tracer
+import brave.Tracing
 import brave.internal.HexCodec
 import org.scalatest.FunSuite
 import zipkin.Span
@@ -109,7 +109,7 @@ class ZipkinTraceServiceLikeSpec extends FunSuite {
 class TestZipkinTraceService extends ZipkinTraceServiceLike {
   override implicit val executionContext: ExecutionContext = ExecutionContext.global
   val reporter = new TestReporter()
-  override val tracer: Tracer = Tracer.newBuilder().reporter(reporter).build()
+  override val tracing: Tracing = Tracing.newBuilder().reporter(reporter).build()
 }
 
 class TestReporter extends Reporter[Span] {

--- a/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
@@ -1,6 +1,6 @@
 package jp.co.bizreach.trace.play23
 
-import brave.Tracer
+import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace._
 import play.api.{Play, Configuration}
@@ -19,7 +19,7 @@ object ZipkinTraceService extends ZipkinTraceServiceLike {
 
   implicit val executionContext: ExecutionContext = Akka.system.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
-  val tracer = Tracer.newBuilder()
+  val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(

--- a/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
@@ -3,7 +3,7 @@ package jp.co.bizreach.trace.play24
 import javax.inject.Inject
 
 import akka.actor.ActorSystem
-import brave.Tracer
+import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceServiceLike, ZipkinTraceConfig}
 import play.api.Configuration
@@ -24,7 +24,7 @@ class ZipkinTraceService @Inject() (
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
-  val tracer = Tracer.newBuilder()
+  val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(

--- a/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
@@ -3,7 +3,7 @@ package jp.co.bizreach.trace.play25
 import javax.inject.Inject
 
 import akka.actor.ActorSystem
-import brave.Tracer
+import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceServiceLike, ZipkinTraceConfig}
 import play.api.Configuration
@@ -24,7 +24,7 @@ class ZipkinTraceService @Inject() (
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
-  val tracer = Tracer.newBuilder()
+  val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
@@ -3,7 +3,7 @@ package jp.co.bizreach.trace.play26
 import javax.inject.Inject
 
 import akka.actor.ActorSystem
-import brave.Tracer
+import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 import play.api.Configuration
@@ -13,7 +13,7 @@ import zipkin.reporter.okhttp3.OkHttpSender
 import scala.concurrent.ExecutionContext
 
 /**
- * Class for Zipkin tracing at Play2.5.
+ * Class for Zipkin tracing at Play2.6.
  *
  * @param conf a Play's configuration
  * @param actorSystem a Play's actor system
@@ -24,7 +24,7 @@ class ZipkinTraceService @Inject() (
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
-  val tracer = Tracer.newBuilder()
+  val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/module/ZipkinModule.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/module/ZipkinModule.scala
@@ -10,7 +10,7 @@ import play.api.{Configuration, Environment}
  *
  * This module can be registered with Play automatically by appending it in application.conf:
  * {{{
- *   play.modules.enabled += "jp.co.bizreach.trace.play25.module.ZipkinModule"
+ *   play.modules.enabled += "jp.co.bizreach.trace.play26.module.ZipkinModule"
  * }}}
  *
  */

--- a/play-zipkin-tracing/project/build.properties
+++ b/play-zipkin-tracing/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.15


### PR DESCRIPTION
`brave.Tracer.newBuilder()` has been deprecated since brave 4.2.0. So fixes to provide `brave.Tracing` instead.

refs #18 