### PR TITLE
Add base-url config key instead of separate host and port

### DIFF
--- a/play-zipkin-tracing/core/src/main/scala/jp/co/bizreach/trace/ZipkinTraceConfig.scala
+++ b/play-zipkin-tracing/core/src/main/scala/jp/co/bizreach/trace/ZipkinTraceConfig.scala
@@ -2,11 +2,7 @@ package jp.co.bizreach.trace
 
 object ZipkinTraceConfig {
   val AkkaName = "zipkin-trace-context"
-
   val ServiceName = "trace.service-name"
-
-  val ZipkinHost = "trace.zipkin.host"
-  val ZipkinPort = "trace.zipkin.port"
+  val ZipkinBaseUrl = "trace.zipkin.base-url"
   val ZipkinSampleRate = "trace.zipkin.sample-rate"
-
 }

--- a/play-zipkin-tracing/play23/README.md
+++ b/play-zipkin-tracing/play23/README.md
@@ -9,7 +9,7 @@ Add following dependency to `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play23" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play23" % "1.2.0-SNAPSHOT"
 )
 ```
 
@@ -20,8 +20,7 @@ trace {
   service-name = "zipkin-api-sample"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
@@ -23,7 +23,7 @@ object ZipkinTraceService extends ZipkinTraceServiceLike {
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
+        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
       ))
       .build()
     )

--- a/play-zipkin-tracing/play24/README.md
+++ b/play-zipkin-tracing/play24/README.md
@@ -9,7 +9,7 @@ Add following configuration to `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play24" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play24" % "1.2.0-SNAPSHOT"
 )
 
 routesGenerator := InjectedRoutesGenerator
@@ -24,8 +24,7 @@ trace {
   service-name = "zipkin-api-sample"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
@@ -28,7 +28,7 @@ class ZipkinTraceService @Inject() (
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
+        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
       ))
       .build()
     )

--- a/play-zipkin-tracing/play25/README.md
+++ b/play-zipkin-tracing/play25/README.md
@@ -9,7 +9,7 @@ Add following dependency to `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play25" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play25" % "1.2.0-SNAPSHOT"
 )
 ```
 
@@ -22,8 +22,7 @@ trace {
   service-name = "zipkin-api-sample"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
@@ -28,7 +28,7 @@ class ZipkinTraceService @Inject() (
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
+        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
       ))
       .build()
     )

--- a/play-zipkin-tracing/play26/README.md
+++ b/play-zipkin-tracing/play26/README.md
@@ -9,7 +9,7 @@ Add following dependency to `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play26" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play26" % "1.2.0-SNAPSHOT"
 )
 ```
 
@@ -22,8 +22,7 @@ trace {
   service-name = "zipkin-api-sample"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 0.1
   }
 }

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
@@ -25,14 +25,14 @@ class ZipkinTraceService @Inject() (
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
   val tracing = Tracing.newBuilder()
-    .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
+    .localServiceName(conf.getOptional[String](ZipkinTraceConfig.ServiceName) getOrElse "unknown")
     .reporter(AsyncReporter
       .builder(OkHttpSender.create(
-        s"http://${conf.getString(ZipkinTraceConfig.ZipkinHost) getOrElse "localhost"}:${conf.getInt(ZipkinTraceConfig.ZipkinPort) getOrElse 9411}/api/v1/spans"
+        (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
       ))
       .build()
     )
-    .sampler(conf.getString(ZipkinTraceConfig.ZipkinSampleRate)
+    .sampler(conf.getOptional[String](ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
     )
     .build()

--- a/sample/zipkin-api-play23/build.sbt
+++ b/sample/zipkin-api-play23/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play23" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play23" % "1.2.0-SNAPSHOT"
 )
 
 

--- a/sample/zipkin-api-play23/conf/application.conf
+++ b/sample/zipkin-api-play23/conf/application.conf
@@ -2,8 +2,7 @@ trace {
   service-name = "zipkin-api-play23"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 1.0
   }
 }

--- a/sample/zipkin-api-play24/build.sbt
+++ b/sample/zipkin-api-play24/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play24" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play24" % "1.2.0-SNAPSHOT"
 )
 
 

--- a/sample/zipkin-api-play24/conf/application.conf
+++ b/sample/zipkin-api-play24/conf/application.conf
@@ -4,8 +4,7 @@ trace {
   service-name = "zipkin-api-play24"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 1.0
   }
 }

--- a/sample/zipkin-api-play25/build.sbt
+++ b/sample/zipkin-api-play25/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
 val AkkaVersion = "2.4.11"
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play25" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play25" % "1.2.0-SNAPSHOT"
 )
 
 PlayKeys.playDefaultPort := 9991

--- a/sample/zipkin-api-play25/conf/application.conf
+++ b/sample/zipkin-api-play25/conf/application.conf
@@ -4,8 +4,7 @@ trace {
   service-name = "zipkin-api-play25"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 1.0
   }
 }

--- a/sample/zipkin-api-play26/build.sbt
+++ b/sample/zipkin-api-play26/build.sbt
@@ -21,7 +21,7 @@ val AkkaVersion = "2.4.11"
 resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
 
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play26" % "1.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play26" % "1.2.0-SNAPSHOT"
 )
 
 PlayKeys.playDefaultPort := 9991

--- a/sample/zipkin-api-play26/conf/application.conf
+++ b/sample/zipkin-api-play26/conf/application.conf
@@ -4,8 +4,7 @@ trace {
   service-name = "zipkin-api-play26"
 
   zipkin {
-    host = "localhost"
-    port = 9411
+    base-url = "http://localhost:9411"
     sample-rate = 1.0
   }
 }


### PR DESCRIPTION
Before:
```
 trace {
   service-name = "zipkin-api-sample"
   zipkin {
     host = "localhost"
     port = 9411
     sample-rate = 0.1
   }
 }
```
After:
```
 trace {
   service-name = "zipkin-api-sample"
   zipkin {
     base-url = "http://localhost:9411"
     sample-rate = 0.1
   }
 }
```
This pull request covers #17.