### PR TITLE
Updates to Zipkin 2 representation

### DIFF
--- a/play-zipkin-tracing/akka/src/main/scala/jp/co/bizreach/trace/akka/actor/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/akka/src/main/scala/jp/co/bizreach/trace/akka/actor/ZipkinTraceService.scala
@@ -25,11 +25,11 @@ class ZipkinTraceService(
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
-  private val sender = OkHttpSender.create(baseUrl + "/api/v1/spans")
+  private val sender = OkHttpSender.json(baseUrl + "/api/v2/spans")
 
   val tracing = Tracing.newBuilder()
     .localServiceName(serviceName)
-    .reporter(AsyncReporter.builder(sender).build())
+    .spanReporter(AsyncReporter.v2(sender))
     .sampler(sampleRate.map(x => Sampler.create(x)) getOrElse Sampler.ALWAYS_SAMPLE)
     .build()
 

--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -63,8 +63,8 @@ lazy val core = (project in file("core")).
     name := "play-zipkin-tracing-core",
     libraryDependencies ++= Seq(
       "commons-lang" % "commons-lang" % "2.6",
-      "io.zipkin.brave" % "brave" % "4.3.3",
-      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "0.10.0",
+      "io.zipkin.brave" % "brave" % "4.7.0",
+      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "1.1.0",
       "org.scalatest" %% "scalatest" % "3.0.3" % "test"
     )
   )

--- a/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
+++ b/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
@@ -3,7 +3,7 @@ package jp.co.bizreach.trace
 import brave.Tracing
 import brave.internal.HexCodec
 import org.scalatest.FunSuite
-import zipkin.Span
+import zipkin2.Span
 import zipkin.reporter.Reporter
 
 import scala.collection.mutable.ListBuffer
@@ -96,12 +96,11 @@ class ZipkinTraceServiceLikeSpec extends FunSuite {
 
     assert(tracer.reporter.spans.length == 1)
 
-    val reported = tracer.reporter.spans.find(_.name == "server-span").get
-    assert(reported.name == "server-span")
-    assert(reported.duration >= 500)
-    assert(reported.binaryAnnotations.size() == 1)
-    assert(reported.binaryAnnotations.get(0).key == "tag")
-    assert(reported.binaryAnnotations.get(0).value === "value".getBytes())
+    val reported = tracer.reporter.spans.find(_.name() == "server-span").get
+    assert(reported.name() == "server-span")
+    assert(reported.duration() >= 500)
+    assert(reported.tags().size() == 1)
+    assert(reported.tags().get("tag") === "value")
   }
 
 }
@@ -109,7 +108,7 @@ class ZipkinTraceServiceLikeSpec extends FunSuite {
 class TestZipkinTraceService extends ZipkinTraceServiceLike {
   override implicit val executionContext: ExecutionContext = ExecutionContext.global
   val reporter = new TestReporter()
-  override val tracing: Tracing = Tracing.newBuilder().reporter(reporter).build()
+  override val tracing: Tracing = Tracing.newBuilder().spanReporter(reporter).build()
 }
 
 class TestReporter extends Reporter[Span] {

--- a/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 import akka.actor.ActorSystem
 import brave.Tracing
 import brave.sampler.Sampler
-import jp.co.bizreach.trace.{ZipkinTraceServiceLike, ZipkinTraceConfig}
+import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 import play.api.Configuration
 import zipkin.reporter.AsyncReporter
 import zipkin.reporter.okhttp3.OkHttpSender
@@ -26,12 +26,9 @@ class ZipkinTraceService @Inject() (
 
   val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .reporter(AsyncReporter
-      .builder(OkHttpSender.create(
-        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
-      ))
-      .build()
-    )
+    .spanReporter(AsyncReporter.builder(OkHttpSender.json(
+      (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
+    )).buildV2())
     .sampler(conf.getString(ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
     )

--- a/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 import akka.actor.ActorSystem
 import brave.Tracing
 import brave.sampler.Sampler
-import jp.co.bizreach.trace.{ZipkinTraceServiceLike, ZipkinTraceConfig}
+import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 import play.api.Configuration
 import zipkin.reporter.AsyncReporter
 import zipkin.reporter.okhttp3.OkHttpSender
@@ -26,12 +26,9 @@ class ZipkinTraceService @Inject() (
 
   val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .reporter(AsyncReporter
-      .builder(OkHttpSender.create(
-        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
-      ))
-      .build()
-    )
+    .spanReporter(AsyncReporter.builder(OkHttpSender.json(
+      (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
+    )).buildV2())
     .sampler(conf.getString(ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
     )

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
@@ -26,12 +26,9 @@ class ZipkinTraceService @Inject() (
 
   val tracing = Tracing.newBuilder()
     .localServiceName(conf.getOptional[String](ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .reporter(AsyncReporter
-      .builder(OkHttpSender.create(
-        (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
-      ))
-      .build()
-    )
+    .spanReporter(AsyncReporter.builder(OkHttpSender.json(
+        (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
+      )).buildV2())
     .sampler(conf.getOptional[String](ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
     )


### PR DESCRIPTION
Zipkin's v2 format is available from server 1.31+ This is a more concise
json variant than before, so easier to troubleshoot. We can try to
detect the server version if assuming a floor server version isn't good.

http://zipkin.io/zipkin-api/#/default/post_spans