### PR TITLE
Updates to Brave 4.8 which supports zipkin reporter2

### DIFF
--- a/play-zipkin-tracing/akka/src/main/scala/jp/co/bizreach/trace/akka/actor/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/akka/src/main/scala/jp/co/bizreach/trace/akka/actor/ZipkinTraceService.scala
@@ -4,8 +4,8 @@ import akka.actor.ActorSystem
 import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
-import zipkin.reporter.AsyncReporter
-import zipkin.reporter.okhttp3.OkHttpSender
+import zipkin2.reporter.AsyncReporter
+import zipkin2.reporter.okhttp3.OkHttpSender
 
 import scala.concurrent.ExecutionContext
 
@@ -25,11 +25,11 @@ class ZipkinTraceService(
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
 
-  private val sender = OkHttpSender.json(baseUrl + "/api/v2/spans")
+  private val sender = OkHttpSender.create(baseUrl + "/api/v2/spans")
 
   val tracing = Tracing.newBuilder()
     .localServiceName(serviceName)
-    .spanReporter(AsyncReporter.v2(sender))
+    .spanReporter(AsyncReporter.create(sender))
     .sampler(sampleRate.map(x => Sampler.create(x)) getOrElse Sampler.ALWAYS_SAMPLE)
     .build()
 

--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -63,8 +63,8 @@ lazy val core = (project in file("core")).
     name := "play-zipkin-tracing-core",
     libraryDependencies ++= Seq(
       "commons-lang" % "commons-lang" % "2.6",
-      "io.zipkin.brave" % "brave" % "4.7.0",
-      "io.zipkin.reporter" % "zipkin-sender-okhttp3" % "1.1.0",
+      "io.zipkin.brave" % "brave" % "4.8.0",
+      "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.0.0",
       "org.scalatest" %% "scalatest" % "3.0.3" % "test"
     )
   )

--- a/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
+++ b/play-zipkin-tracing/core/src/test/scala/jp/co/bizreach/trace/ZipkinTraceServiceLikeSpec.scala
@@ -4,7 +4,7 @@ import brave.Tracing
 import brave.internal.HexCodec
 import org.scalatest.FunSuite
 import zipkin2.Span
-import zipkin.reporter.Reporter
+import zipkin2.reporter.Reporter
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.Duration

--- a/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play23/src/main/scala/jp/co/bizreach/trace/play23/ZipkinTraceService.scala
@@ -5,8 +5,8 @@ import brave.sampler.Sampler
 import jp.co.bizreach.trace._
 import play.api.{Play, Configuration}
 import play.api.libs.concurrent.Akka
-import zipkin.reporter.AsyncReporter
-import zipkin.reporter.okhttp3.OkHttpSender
+import zipkin2.reporter.AsyncReporter
+import zipkin2.reporter.okhttp3.OkHttpSender
 
 import scala.concurrent.ExecutionContext
 
@@ -21,11 +21,10 @@ object ZipkinTraceService extends ZipkinTraceServiceLike {
 
   val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .reporter(AsyncReporter
-      .builder(OkHttpSender.create(
-        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v1/spans"
+    .spanReporter(AsyncReporter
+      .create(OkHttpSender.create(
+        (conf.getString(ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
       ))
-      .build()
     )
     .sampler(conf.getString(ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE

--- a/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play24/src/main/scala/jp/co/bizreach/trace/play24/ZipkinTraceService.scala
@@ -7,8 +7,8 @@ import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 import play.api.Configuration
-import zipkin.reporter.AsyncReporter
-import zipkin.reporter.okhttp3.OkHttpSender
+import zipkin2.reporter.AsyncReporter
+import zipkin2.reporter.okhttp3.OkHttpSender
 
 import scala.concurrent.ExecutionContext
 

--- a/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play25/src/main/scala/jp/co/bizreach/trace/play25/ZipkinTraceService.scala
@@ -7,8 +7,8 @@ import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 import play.api.Configuration
-import zipkin.reporter.AsyncReporter
-import zipkin.reporter.okhttp3.OkHttpSender
+import zipkin2.reporter.AsyncReporter
+import zipkin2.reporter.okhttp3.OkHttpSender
 
 import scala.concurrent.ExecutionContext
 
@@ -26,9 +26,9 @@ class ZipkinTraceService @Inject() (
 
   val tracing = Tracing.newBuilder()
     .localServiceName(conf.getString(ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .spanReporter(AsyncReporter.builder(OkHttpSender.json(
+    .spanReporter(AsyncReporter.create(OkHttpSender.create(
       (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
-    )).buildV2())
+    )))
     .sampler(conf.getString(ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
     )

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
@@ -7,8 +7,8 @@ import brave.Tracing
 import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 import play.api.Configuration
-import zipkin.reporter.AsyncReporter
-import zipkin.reporter.okhttp3.OkHttpSender
+import zipkin2.reporter.AsyncReporter
+import zipkin2.reporter.okhttp3.OkHttpSender
 
 import scala.concurrent.ExecutionContext
 
@@ -26,9 +26,9 @@ class ZipkinTraceService @Inject() (
 
   val tracing = Tracing.newBuilder()
     .localServiceName(conf.getOptional[String](ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .spanReporter(AsyncReporter.builder(OkHttpSender.json(
+    .spanReporter(AsyncReporter.create(OkHttpSender.create(
         (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
-      )).buildV2())
+      )))
     .sampler(conf.getOptional[String](ZipkinTraceConfig.ZipkinSampleRate)
       .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
     )


### PR DESCRIPTION
This drops the dependency on v1 of zipkin-reporter eventhough you can still write the old format if you want like..

```
reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
                        .build(SpanBytesEncoder.JSON_V1);
```