### PR TITLE
WIP configurable tracing

### DIFF
--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -90,7 +90,8 @@ lazy val play26 = (project in file("play26")).
     name := "play-zipkin-tracing-play26",
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % play26Version % Provided,
-      "com.typesafe.play" %% "play-ws" % play26Version % Provided
+      "com.typesafe.play" %% "play-ws" % play26Version % Provided,
+      "com.typesafe.play" %% "play-guice" % play26Version % Test
     )
   ).dependsOn(
     core % "test->test;compile->compile",

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
@@ -4,34 +4,19 @@ import javax.inject.Inject
 
 import akka.actor.ActorSystem
 import brave.Tracing
-import brave.sampler.Sampler
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
-import play.api.Configuration
-import zipkin2.reporter.AsyncReporter
-import zipkin2.reporter.okhttp3.OkHttpSender
 
 import scala.concurrent.ExecutionContext
 
 /**
  * Class for Zipkin tracing at Play2.6.
  *
- * @param conf a Play's configuration
+ * @param tracing a Play's configuration
  * @param actorSystem a Play's actor system
  */
 class ZipkinTraceService @Inject() (
-  conf: Configuration,
+  val tracing: Tracing,
   actorSystem: ActorSystem) extends ZipkinTraceServiceLike {
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)
-
-  val tracing = Tracing.newBuilder()
-    .localServiceName(conf.getOptional[String](ZipkinTraceConfig.ServiceName) getOrElse "unknown")
-    .spanReporter(AsyncReporter.create(OkHttpSender.create(
-        (conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411") + "/api/v2/spans"
-      )))
-    .sampler(conf.getOptional[String](ZipkinTraceConfig.ZipkinSampleRate)
-      .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
-    )
-    .build()
-
 }

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/module/ZipkinModule.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/module/ZipkinModule.scala
@@ -1,23 +1,62 @@
 package jp.co.bizreach.trace.play26.module
 
-import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import javax.inject.{Inject, Provider}
+
+import brave.Tracing
+import brave.sampler.Sampler
 import jp.co.bizreach.trace.play26.ZipkinTraceService
-import play.api.inject.{Binding, Module}
-import play.api.{Configuration, Environment}
+import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
+import play.api.Configuration
+import play.api.inject.{ApplicationLifecycle, SimpleModule, bind}
+import zipkin2.reporter.okhttp3.OkHttpSender
+import zipkin2.reporter.{AsyncReporter, Sender}
+
+import scala.concurrent.Future
 
 /**
- * A Zipkin module.
- *
- * This module can be registered with Play automatically by appending it in application.conf:
- * {{{
- *   play.modules.enabled += "jp.co.bizreach.trace.play26.module.ZipkinModule"
- * }}}
- *
- */
-class ZipkinModule extends Module {
-  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    Seq(
-      bind[ZipkinTraceServiceLike].to[ZipkinTraceService]
-    )
+  * A Zipkin module.
+  *
+  * This module can be registered with Play automatically by appending it in application.conf:
+  * {{{
+  *   play.modules.enabled += "jp.co.bizreach.trace.play26.module.ZipkinModule"
+  * }}}
+  *
+  */
+class ZipkinModule extends SimpleModule((env, conf) =>
+  Seq(
+    bind[Sender].toProvider(classOf[SenderProvider]),
+    bind[Tracing].toProvider(classOf[TracingProvider]),
+    bind[ZipkinTraceServiceLike].to[ZipkinTraceService]
+  )
+)
+
+class SenderProvider @Inject()(conf: Configuration, lifecycle: ApplicationLifecycle) extends Provider[Sender] {
+  override def get(): Sender = {
+    val baseUrl = conf.getOptional[String](ZipkinTraceConfig.ZipkinBaseUrl) getOrElse "http://localhost:9411"
+    val result = OkHttpSender.create(baseUrl + "/api/v2/spans")
+    lifecycle.addStopHook(() => Future.successful(result.close()))
+    result
+  }
+}
+
+class TracingProvider @Inject()(sender: Provider[Sender],
+                                conf: Configuration,
+                                lifecycle: ApplicationLifecycle)
+  extends Provider[Tracing] {
+
+  override def get(): Tracing = {
+    // not injecting a span reporter, as you can't bind parameterized types like
+    // Reporter[Span] here per https://github.com/playframework/playframework/issues/3422
+    val spanReporter = AsyncReporter.create(sender.get())
+    lifecycle.addStopHook(() => Future.successful(spanReporter.close()))
+    val result = Tracing.newBuilder()
+      .localServiceName(conf.getOptional[String](ZipkinTraceConfig.ServiceName) getOrElse "unknown")
+      .spanReporter(spanReporter)
+      .sampler(conf.getOptional[String](ZipkinTraceConfig.ZipkinSampleRate)
+        .map(s => Sampler.create(s.toFloat)) getOrElse Sampler.ALWAYS_SAMPLE
+      )
+      .build()
+    lifecycle.addStopHook(() => Future.successful(result.close()))
+    result
   }
 }

--- a/play-zipkin-tracing/play26/src/test/java/jp/co/bizreach/trace/ZipkinModuleSpec.scala
+++ b/play-zipkin-tracing/play26/src/test/java/jp/co/bizreach/trace/ZipkinModuleSpec.scala
@@ -1,0 +1,61 @@
+package jp.co.bizreach.trace.play26.module
+
+import java.util.Collections
+
+import brave.Tracing
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import jp.co.bizreach.trace.play26.ZipkinTraceService
+import org.scalatest.AsyncFlatSpec
+import play.api.inject.ApplicationLifecycle
+import play.api.inject.guice.GuiceApplicationBuilder
+import zipkin2.reporter.Sender
+import zipkin2.reporter.okhttp3.OkHttpSender
+
+
+class ZipkinModuleSpec extends AsyncFlatSpec {
+  val injector = new GuiceApplicationBuilder()
+    .bindings(new ZipkinModule)
+    .injector()
+
+  it should "provide an okhttp sender" in {
+    val sender = injector.instanceOf[Sender]
+    assert(sender.isInstanceOf[OkHttpSender])
+  }
+
+  it should "eventually close the sender" in {
+    // provisioning the sender so we can tell if it is closed on shutdown
+    val sender = injector.instanceOf[Sender]
+
+    // stopping the application should close the sender!
+    injector.instanceOf[ApplicationLifecycle].stop map { _ => {
+      val thrown = intercept[Exception] {
+        sender.sendSpans(Collections.emptyList[Array[Byte]]).execute()
+      }
+      assert(thrown.getMessage === "closed")
+    }
+    }
+  }
+
+  it should "provide a tracing component" in {
+    val tracing = injector.instanceOf[Tracing]
+    assert(Tracing.current() != null)
+  }
+
+  it should "eventually close the tracing component" in {
+    // provisioning the tracing component so we can tell if it is closed on shutdown
+    val tracing = injector.instanceOf[Tracing]
+
+    // stopping the application should close the tracing component!
+    injector.instanceOf[ApplicationLifecycle].stop map { _ => {
+      assert(Tracing.current() == null)
+
+    }
+    }
+  }
+
+  it should "provide a zipkin trace service" in {
+    // TODO: dies due to missing dispatcher
+    val service = injector.instanceOf[ZipkinTraceServiceLike]
+    assert(service.isInstanceOf[ZipkinTraceService])
+  }
+}

--- a/play-zipkin-tracing/play26/src/test/resources/application.conf
+++ b/play-zipkin-tracing/play26/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+zipkin-trace-context {
+  fork-join-executor {
+    parallelism-factor = 20.0
+    parallelism-max = 200
+  }
+}


### PR DESCRIPTION
This creates a tracing module from parts, and ensures lifecycle methods
are invoked. This is part of getting to where we can inject HttpTracing.

The test needs to be fixed as I don't know best way to configure the
dispatcher. It seems some sharing can be done between play and akka,
possibly.

Help wanted on moving this farther.. once refactored I can help with
getting HttpTracing stitched together.