### PR TITLE
Adds http integration tests 

### DIFF
--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -63,10 +63,11 @@ lazy val core = (project in file("core")).
     name := "play-zipkin-tracing-core",
     libraryDependencies ++= Seq(
       "commons-lang" % "commons-lang" % "2.6",
-      "io.zipkin.brave" % "brave" % "4.12.0",
-      "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.2.0",
+      "io.zipkin.brave" % "brave" % "4.15.1",
+      "io.zipkin.brave" % "brave-instrumentation-http" % "4.15.1",
+      "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.3.2",
       "org.scalatest" %% "scalatest" % "3.0.3" % "test",
-      "io.zipkin.brave" % "brave-tests" % "4.12.0" % "test",
+      "io.zipkin.brave" % "brave-tests" % "4.15.1" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"
     ),
@@ -91,7 +92,9 @@ lazy val play26 = (project in file("play26")).
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play" % play26Version % Provided,
       "com.typesafe.play" %% "play-ws" % play26Version % Provided,
-      "com.typesafe.play" %% "play-guice" % play26Version % Test
+      "com.typesafe.play" %% "play-test" % play26Version % Test,
+      "com.typesafe.play" %% "play-guice" % play26Version % Test,
+      "io.zipkin.brave" % "brave-instrumentation-http-tests" % "4.15.1" % Test
     )
   ).dependsOn(
     core % "test->test;compile->compile",

--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -1,3 +1,5 @@
+resolvers in Global += Resolver.mavenLocal
+
 lazy val commonSettings = Seq(
   organization := "jp.co.bizreach",
   version := "2.0.1",
@@ -63,11 +65,11 @@ lazy val core = (project in file("core")).
     name := "play-zipkin-tracing-core",
     libraryDependencies ++= Seq(
       "commons-lang" % "commons-lang" % "2.6",
-      "io.zipkin.brave" % "brave" % "4.15.1",
-      "io.zipkin.brave" % "brave-instrumentation-http" % "4.15.1",
-      "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.3.2",
+      "io.zipkin.brave" % "brave" % "4.16.1",
+      "io.zipkin.brave" % "brave-instrumentation-http" % "4.16.1",
+      "io.zipkin.reporter2" % "zipkin-sender-okhttp3" % "2.3.3",
       "org.scalatest" %% "scalatest" % "3.0.3" % "test",
-      "io.zipkin.brave" % "brave-tests" % "4.15.1" % "test",
+      "io.zipkin.brave" % "brave-tests" % "4.16.1" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test"
     ),
@@ -94,7 +96,7 @@ lazy val play26 = (project in file("play26")).
       "com.typesafe.play" %% "play-ws" % play26Version % Provided,
       "com.typesafe.play" %% "play-test" % play26Version % Test,
       "com.typesafe.play" %% "play-guice" % play26Version % Test,
-      "io.zipkin.brave" % "brave-instrumentation-http-tests" % "4.15.1" % Test
+      "io.zipkin.brave" % "brave-instrumentation-http-tests" % "4.16.1" % Test
     )
   ).dependsOn(
     core % "test->test;compile->compile",

--- a/play-zipkin-tracing/core/src/main/scala/jp/co/bizreach/trace/ZipkinTraceServiceLike.scala
+++ b/play-zipkin-tracing/core/src/main/scala/jp/co/bizreach/trace/ZipkinTraceServiceLike.scala
@@ -1,5 +1,6 @@
 package jp.co.bizreach.trace
 
+import brave.http.HttpTracing
 import brave.propagation.{Propagation, TraceContext}
 import brave.{Span, Tracer, Tracing}
 
@@ -38,7 +39,8 @@ trait ZipkinTraceServiceLike {
   // used by a tracer report data to Zipkin
   implicit val executionContext: ExecutionContext
   val tracing: Tracing
-  lazy val mapInjector = tracing.propagation().injector(ZipkinTraceServiceLike.mapSetter)
+  val httpTracing = HttpTracing.create(tracing)
+  val mapInjector = tracing.propagation().injector(ZipkinTraceServiceLike.mapSetter)
 
   private def tracer: Tracer = tracing.tracer
 

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/ZipkinTraceService.scala
@@ -4,6 +4,7 @@ import javax.inject.Inject
 
 import akka.actor.ActorSystem
 import brave.Tracing
+import brave.http.HttpTracing
 import jp.co.bizreach.trace.{ZipkinTraceConfig, ZipkinTraceServiceLike}
 
 import scala.concurrent.ExecutionContext
@@ -11,11 +12,13 @@ import scala.concurrent.ExecutionContext
 /**
  * Class for Zipkin tracing at Play2.6.
  *
- * @param tracing a Play's configuration
+ * @param tracing     low-level tracing apis and configuration
+ * @param httpTracing http-layer tracing apis and configuration
  * @param actorSystem a Play's actor system
  */
 class ZipkinTraceService @Inject() (
   val tracing: Tracing,
+  override val httpTracing: HttpTracing,
   actorSystem: ActorSystem) extends ZipkinTraceServiceLike {
 
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup(ZipkinTraceConfig.AkkaName)

--- a/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/filter/ZipkinTraceFilter.scala
+++ b/play-zipkin-tracing/play26/src/main/scala/jp/co/bizreach/trace/play26/filter/ZipkinTraceFilter.scala
@@ -3,12 +3,16 @@ package jp.co.bizreach.trace.play26.filter
 import javax.inject.Inject
 
 import akka.stream.Materializer
+import brave.http.{HttpServerAdapter, HttpServerHandler}
+import brave.propagation.Propagation.Getter
+import brave.propagation.TraceContext
 import jp.co.bizreach.trace.ZipkinTraceServiceLike
 import play.api.mvc.{Filter, Headers, RequestHeader, Result}
 import play.api.routing.Router
+import zipkin2.Endpoint
 
 import scala.concurrent.Future
-import scala.util.Failure
+import scala.util.{Failure, Success}
 
 /**
  * A Zipkin filter.
@@ -29,23 +33,50 @@ class ZipkinTraceFilter @Inject() (tracer: ZipkinTraceServiceLike)(implicit val 
   import tracer.executionContext
   private val reqHeaderToSpanName: RequestHeader => String = ZipkinTraceFilter.ParamAwareRequestNamer
 
+  // TODO: any way to get rid of this asInstanceOf?
+  private val handler: HttpServerHandler[RequestHeader, Result] =
+    HttpServerHandler.create(tracer.httpTracing, new HttpAdapter)
+      .asInstanceOf[HttpServerHandler[RequestHeader, Result]]
+  private val extractor: TraceContext.Extractor[Headers] =
+    tracer.httpTracing.tracing.propagation.extractor(ZipkinTraceFilter.headerGetter)
+
   def apply(nextFilter: (RequestHeader) => Future[Result])(req: RequestHeader): Future[Result] = {
-    val serverSpan = tracer.serverReceived(
-      spanName = reqHeaderToSpanName(req),
-      span = tracer.newSpan(req.headers)((headers, key) => headers.get(key))
-    )
-    val result = nextFilter(req.withHeaders(new Headers(
-      (req.headers.toMap.mapValues(_.headOption getOrElse "") ++ tracer.toMap(serverSpan)).toSeq
-    )))
+    val span = handler.handleReceive(extractor, req.headers, req)
+
+    // invoke the next filter with this span in scope
+    val scope = tracer.tracing.currentTraceContext().newScope(span.context())
+    val result = try {
+      nextFilter(req)
+    } finally {
+      scope.close()
+    }
+
     result.onComplete {
-      case Failure(t) => tracer.serverSend(serverSpan, "failed" -> s"Finished with exception: ${t.getMessage}")
-      case _ => tracer.serverSend(serverSpan)
+      case Failure(t) => handler.handleSend(null, t, span)
+      case Success(r) => handler.handleSend(r, null, span)
     }
     result
+  }
+
+  class HttpAdapter extends HttpServerAdapter[RequestHeader, Result] {
+    override def method(req: RequestHeader) = req.method
+
+    override def url(req: RequestHeader) =
+      "http" + (if (req.secure) "s" else "") + "://" + req.host + req.uri
+
+    override def requestHeader(req: RequestHeader, name: String) = req.headers.get(name).orNull
+
+    override def statusCode(response: Result) = response.header.status
+
+    override def parseClientAddress(req: RequestHeader, builder: Endpoint.Builder): Boolean = {
+      if (super.parseClientAddress(req, builder)) return true
+      builder.parseIp(req.remoteAddress)
+    }
   }
 }
 
 object ZipkinTraceFilter {
+  val headerGetter: Getter[Headers, String] = (headers, key) => headers.get(key).orNull
   val ParamAwareRequestNamer: RequestHeader => String = { reqHeader =>
     import org.apache.commons.lang3.StringUtils
     val pathPattern = StringUtils.replace(

--- a/play-zipkin-tracing/play26/src/test/scala/jp/co/bizreach/trace/play26/filter/ZipkinTraceFilterTest.scala
+++ b/play-zipkin-tracing/play26/src/test/scala/jp/co/bizreach/trace/play26/filter/ZipkinTraceFilterTest.scala
@@ -25,6 +25,10 @@ class TestRouter @Inject()(
   import zipkin.executionContext
 
   override def routes: Routes = {
+    case OPTIONS(p"/") => Action {
+      Results.Ok("bar")
+    }
+
     case GET(p"/foo") => Action {
       Results.Ok("bar")
     }
@@ -61,6 +65,11 @@ class TestRouter @Inject()(
         Results.Ok("This page will generate an error!")
       }
     }
+
+    case GET(p"/items/$itemId<[0-9]+>") => Action {
+      Results.Ok(itemId)
+    }
+      // TODO: how do I make a nested route? Ex "/nested" -> GET(p"/items/$itemId<[0-9]+>")
   }
 }
 

--- a/play-zipkin-tracing/play26/src/test/scala/jp/co/bizreach/trace/play26/filter/ZipkinTraceFilterTest.scala
+++ b/play-zipkin-tracing/play26/src/test/scala/jp/co/bizreach/trace/play26/filter/ZipkinTraceFilterTest.scala
@@ -1,0 +1,109 @@
+package jp.co.bizreach.trace.play26.filter
+
+import javax.inject.Inject
+
+import brave.Tracing
+import brave.http.{HttpTracing, ITHttp, ITHttpServer}
+import brave.propagation.ExtraFieldPropagation
+import jp.co.bizreach.trace.ZipkinTraceServiceLike
+import jp.co.bizreach.trace.play26.ZipkinTraceService
+import org.junit.{After, AssumptionViolatedException}
+import play.api.http.DefaultHttpFilters
+import play.api.inject._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.{Action, Results}
+import play.api.routing.Router.Routes
+import play.api.routing.sird._
+import play.api.routing.{Router, SimpleRouter}
+import play.test._
+
+import scala.concurrent.Future
+
+class TestRouter @Inject()(
+  val zipkin: ZipkinTraceServiceLike
+) extends SimpleRouter {
+  import zipkin.executionContext
+
+  override def routes: Routes = {
+    case GET(p"/foo") => Action {
+      Results.Ok("bar")
+    }
+
+    case GET(p"/async") => Action.async {
+      Future {
+        // Call some blocking API
+        Results.Ok("result of blocking call")
+      }
+    }
+
+    case GET(p"/extra") => Action {
+      Results.Ok(ExtraFieldPropagation.get(ITHttp.EXTRA_KEY))
+    }
+
+    case GET(p"/badrequest") => Action {
+      Results.BadRequest
+    }
+
+    case GET(p"/child") => Action {
+      zipkin.tracing.tracer.nextSpan.name("child").start.finish()
+      Results.Ok("happy")
+    }
+
+    // approach borrowed from kamon.play.RequestHandlerInstrumentationSpec
+    case GET(p"/exception") => Action {
+      throw new Exception()
+      Results.Ok("This page will generate an error!")
+    }
+
+    case GET(p"/exceptionAsync") => Action.async {
+      Future {
+        throw new Exception()
+        Results.Ok("This page will generate an error!")
+      }
+    }
+  }
+}
+
+class Filters @Inject() (
+  zipkin: ZipkinTraceFilter
+) extends DefaultHttpFilters(zipkin)
+
+// Uses some hints from https://github.com/kamon-io/kamon-play/blob/master/kamon-play-2.6.x/src/test/scala/kamon/play/RequestInstrumentationSpec.scala
+class ZipkinTraceFilterTest extends ITHttpServer {
+  var testServer: TestServer = _
+
+  override def init(): Unit = {
+    val port = play.api.test.Helpers.testServerPort
+    val app = new GuiceApplicationBuilder()
+      .configure("play.http.filters" -> classOf[Filters].getName)
+      .overrides(
+        bind[Tracing].toInstance(httpTracing.tracing()),
+        bind[HttpTracing].toInstance(httpTracing),
+        bind[ZipkinTraceServiceLike].to[ZipkinTraceService],
+        bind[Router].to[TestRouter]
+      )
+      .build()
+    // prefer to use port 0 and then lookup the value it uses, but that doesn't work
+    testServer = new TestServer(port, app.asJava)
+    testServer.start()
+  }
+
+  @After def stop(): Unit = {
+    if (testServer != null) testServer.stop()
+  }
+
+  override def readsExtra_existingTrace() =
+    throw new AssumptionViolatedException("TODO: Request handlers cannot read Tracer.currentSpan")
+
+  override def readsExtra_newTrace() =
+    throw new AssumptionViolatedException("TODO: Request handlers cannot read Tracer.currentSpan")
+
+  override def readsExtra_unsampled() =
+    throw new AssumptionViolatedException("TODO: Request handlers cannot read Tracer.currentSpan")
+
+  override def createsChildSpan() =
+    throw new AssumptionViolatedException("TODO: Request handlers cannot read Tracer.currentSpan")
+
+  override def url(path: String) = s"http://localhost:${testServer.port}${path}"
+}
+


### PR DESCRIPTION
Many thanks to Kamon https://github.com/kamon-io/kamon-play/blob/master/kamon-play-2.6.x/src/test/scala/kamon/play/RequestInstrumentationSpec.scala as I used some approaches there to weld brave tests into this. It isn't a great job of it, but starting to work.

this test fails as the current span is not in scope, making the child a part of a different trace. I'm not sure where the scoping of the span is missing