### PR TITLE
Release 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 play-zipkin-tracing [![Build Status](https://travis-ci.org/bizreach/play-zipkin-tracing.svg?branch=master)](https://travis-ci.org/bizreach/play-zipkin-tracing)
 ========
 
-Provides distributed tracing for Play Framework using [Zipkin](http://zipkin.io/). It makes possible to trace HTTP calls between Play based microservices easily without performance degradation.
+Provides distributed tracing for Play Framework using [Zipkin](https://zipkin.io/). It makes possible to trace HTTP calls between Play based microservices easily without performance degradation.
 
 ## Supported versions
 
 - [Akka 2.5.x](play-zipkin-tracing/akka/README.md) (Zipkin1 and Zipkin2 support are available)
-- [Play 2.6](https://github.com/bizreach/play-zipkin-tracing/blob/2.1.0/play-zipkin-tracing/play/README.md) (Zipkin1 and Zipkin2 support are available)
+- [Play 2.7](play-zipkin-tracing/play/README.md) (Zipkin1 and Zipkin2 support are available)
 
 ## Old versions (currently unsupported)
 
+- [Play 2.6](https://github.com/bizreach/play-zipkin-tracing/blob/2.1.0/play-zipkin-tracing/play/README.md) (Zipkin1 and Zipkin2 support are available)
 - [Play 2.5](https://github.com/bizreach/play-zipkin-tracing/blob/1.2.0/play-zipkin-tracing/play25/README.md) (only Zipkin1 support is available)
 - [Play 2.4](https://github.com/bizreach/play-zipkin-tracing/blob/1.2.0/play-zipkin-tracing/play24/README.md) (only Zipkin1 support is available)
 - [Play 2.3](https://github.com/bizreach/play-zipkin-tracing/blob/1.2.0/play-zipkin-tracing/play23/README.md) (only Zipkin1 support is available)

--- a/play-zipkin-tracing/akka/README.md
+++ b/play-zipkin-tracing/akka/README.md
@@ -9,7 +9,7 @@ Add following dependency to `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-akka" % "2.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-akka" % "2.2.0"
 )
 ```
 

--- a/play-zipkin-tracing/build.sbt
+++ b/play-zipkin-tracing/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "jp.co.bizreach",
-  version := "2.2.0-SNAPSHOT",
+  version := "2.2.0",
   scalaVersion := "2.12.8",
   crossScalaVersions := Seq(scalaVersion.value, "2.13.0-M5"),
   publishMavenStyle := true,

--- a/play-zipkin-tracing/play/README.md
+++ b/play-zipkin-tracing/play/README.md
@@ -1,7 +1,7 @@
 play-zipkin-tracing-play
 ========
 
-A library to add tracing capability to Play 2.6 based microservices.
+A library to add tracing capability to Play 2.7 based microservices.
 
 ## Setup
 
@@ -9,7 +9,7 @@ Add following dependency to `build.sbt`:
 
 ```scala
 libraryDependencies ++= Seq(
-  "jp.co.bizreach" %% "play-zipkin-tracing-play" % "2.1.0"
+  "jp.co.bizreach" %% "play-zipkin-tracing-play" % "2.2.0"
 )
 ```
 


### PR DESCRIPTION
- Supported versions
    - Akka 2.5.x
    - Play 2.7
- Bump brave version to 5.6.1

After release, we need to update sample projects.