### PR TITLE
Use nextSpan instead of joinSpan

### DIFF
--- a/core/src/main/scala/brave/play/ZipkinTraceServiceLike.scala
+++ b/core/src/main/scala/brave/play/ZipkinTraceServiceLike.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2020 The OpenZipkin Authors
+ * Copyright 2017-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -183,7 +183,8 @@ trait ZipkinTraceServiceLike {
       (carrier: A, key: String) => getHeader(carrier, key).orNull
     ).extract(headers)
 
-    tracer.joinSpan(contextOrFlags.context())
+    Option(contextOrFlags.context())
+      .map(tracer.joinSpan).getOrElse(tracer.nextSpan(contextOrFlags))
   }
 
   /**

--- a/core/src/test/scala/brave/play/ZipkinTraceServiceLikeSpec.scala
+++ b/core/src/test/scala/brave/play/ZipkinTraceServiceLikeSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2020 The OpenZipkin Authors
+ * Copyright 2017-2021 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -114,6 +114,14 @@ class ZipkinTraceServiceLikeSpec extends FunSuite {
     assert(reported.tags.get("tag") === "value")
   }
 
+  test("when sampling is disabled, toSpan results in a new unsampled trace") {
+    val tracer = new TestZipkinTraceService()
+
+    val parent = tracer.toSpan(Map("X-B3-Sampled" -> "0"))(getValueFromMap)
+
+    assert(parent.context().parentId() == null)
+    assert(parent.context().sampled() == false)
+  }
 }
 
 class TestZipkinTraceService extends ZipkinTraceServiceLike {


### PR DESCRIPTION
To account for the case when `contextOrFlags.context() == null`